### PR TITLE
Add the url filter

### DIFF
--- a/src/mkdocs/rewrite_urls.py
+++ b/src/mkdocs/rewrite_urls.py
@@ -12,6 +12,7 @@ page_context = contextvars.ContextVar('page_context')
 def joinpath(x: pathlib.Path, y: pathlib.Path):
     return pathlib.Path(os.path.normpath(x.joinpath(y)))
 
+
 class PageContext:
     def __init__(self, path: pathlib.Path, path_to_url: dict[pathlib.Path, str], relative: bool):
         self.path = path

--- a/src/mkdocs/theme/templates/base.html
+++ b/src/mkdocs/theme/templates/base.html
@@ -4,12 +4,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{ config.site.title }}</title>
         <link rel="icon" href="data:image/svg+xml,{% include 'favicon.svg' %}">
-        <link rel="stylesheet" href="/css/highlightjs.min.css">
-        <link rel="stylesheet" href="/css/highlightjs-copy.min.css">
-        <link rel="stylesheet" href="/css/theme.css">
-        <script src="/js/highlightjs.min.js"></script>
-        <script src="/js/highlightjs-copy.min.js"></script>
-        <script src="/js/theme.js"></script>
+        <link rel="stylesheet" href="{{ '/css/highlightjs.min.css' | url }}">
+        <link rel="stylesheet" href="{{ '/css/highlightjs-copy.min.css' | url }}">
+        <link rel="stylesheet" href="{{ '/css/theme.css' | url }}">
+        <script src="{{ '/js/highlightjs.min.js' | url }}"></script>
+        <script src="{{ '/js/highlightjs-copy.min.js' | url }}"></script>
+        <script src="{{ '/js/theme.js' | url }}"></script>
     </head>
     <body>
         <nav class="left">


### PR DESCRIPTION
Eg. the `https://www.encode.io/mkdocs/` site is deployed and hosted under a subdirectory.