### PR TITLE
docs: clarify installation step and remove $ prompt confusion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,15 @@
 
 MkDocs is a smart, simple, website design tool.
 
-Getting started is easy...
+## Installation
+
+To install MkDocs, run the following command from the command line:
 
 ```shell
-$ pip install mkdocs --pre
+pip install mkdocs --pre
 ```
 
-*This will install the version 2.0 pre-release.*
+This will install the version 2.0 pre-release.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
Small documentation improvement to `docs/README.md`, based on going through the getting-started flow as a first-time user of the v2 pre-release.

## Changes

**Clarified the installation step**

Changed:
```
Getting started is easy...

$ pip install mkdocs --pre

This will install the version 2.0 pre-release.
```

To:
```markdown
## Installation

To install MkDocs, run the following command from the command line:

pip install mkdocs --pre

This will install the version 2.0 pre-release.
```

**Why:** The original `$ pip install...` format could be misread as part of the literal command to type (the `$` is a conventional shell-prompt symbol, not something to enter) — confirmed this is a real point of confusion by testing it myself. Removing it and adding a clear instructional sentence avoids that confusion for newcomers. Gave the step its own heading for scannability, matching the style used on mkdocs.org.