### PR TITLE
Navigation support bugfix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 **Navigation Support Bugfix**
 
-Use relative URLs for site navigation. Ensures that sites hosted on a subpath still link correctly.
+Use relative URLs for site navigation. Ensures that sites hosted on a subpath still link correctly. [#54](https://github.com/encode/mkdocs/pull/54)
 
 ## 2.0.dev4
 
 **Navigation Support**
 
-Preliminary support for site navigation.
-
-See [#49](https://github.com/encode/mkdocs/pull/49) for further details.
+Preliminary support for site navigation. [#49](https://github.com/encode/mkdocs/pull/49)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.dev5
+
+**Navigation Support Bugfix**
+
+Use relative URLs for site navigation. Ensures that sites hosted on a subpath still link correctly.
+
 ## 2.0.dev4
 
 **Navigation Support**

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         <nav class="site">
-            {{ nav.html }}
+            {% include "navigation.html" %}
         </nav>
         <nav class="toc">
             {{ page.toc.html }}

--- a/docs/templates/navigation.html
+++ b/docs/templates/navigation.html
@@ -1,0 +1,3 @@
+<ul>
+    {% for item in nav %}<li><a href="{{ item.page.url | url }}"{% if item.page.url == page.url %} class="active"{% endif %}>{{ item.title }}</a></li>{% endfor %}
+</ul>

--- a/src/mkdocs/__version__.py
+++ b/src/mkdocs/__version__.py
@@ -1,2 +1,2 @@
 __title__ = "mkdocs"
-__version__ = "2.0.dev4"
+__version__ = "2.0.dev5"

--- a/src/mkdocs/extensions/relative_urls.py
+++ b/src/mkdocs/extensions/relative_urls.py
@@ -40,9 +40,7 @@ class URLProcessor(markdown.treeprocessors.Treeprocessor):
 
                     url_from = page.url
                     url_to = target.url
-                    rewrite = posixpath.relpath(url_to, url_from)
-                    if url_to.endswith('/') and rewrite != '.':
-                        rewrite += '/'
+                    rewrite = mkdocs.link_to(url_from, url_to)
                     if url.query:
                         rewrite += f'?{url.query}'
                     if url.fragment:

--- a/src/mkdocs/mkdocs.py
+++ b/src/mkdocs/mkdocs.py
@@ -37,6 +37,18 @@ def get_site():
     return ctx
 
 
+def link_to(path_from, path_to):
+    if path_from == path_to:
+        return '.'
+    p0 = path_from.split('/')
+    p1 = path_to.split('/')
+    for idx, pair in enumerate(zip(p0, p1)):
+        if pair[0] != pair[1]:
+            break
+    p = ['..' for i in p0[idx+1:]] + p1[idx:]
+    return '/'.join(p)
+
+
 class Page:
     def __init__(self, path):
         self.path = path
@@ -194,8 +206,7 @@ class MkDocs:
         @jinja2.pass_context
         def url(ctx, url_to):
             url_from = ctx['page'].url
-            url_rel = posixpath.relpath(url_to, url_from)  # This isn't correct
-            return url_rel
+            return link_to(url_from, url_to)
 
         dir = pathlib.Path(input_dir)
         loader = jinja2.ChoiceLoader([


### PR DESCRIPTION
Use relative URLs for site navigation.

Ensures that sites hosted on a subpath still link correctly.

Eg...
<img width="484" height="251" alt="image" src="https://github.com/user-attachments/assets/33d9012c-5fba-407e-a5e2-fdd68a9b53ef" />

<img width="345" height="177" alt="image" src="https://github.com/user-attachments/assets/01576a85-24ba-442a-86ca-06e15c164a44" />

---

This will interlink correctly if the site is hosted on at a root path...

* `https://mkdocs.org/...`

Or if the site is hosted on a subpath...

* `https://encode.io/mkdocs/...`